### PR TITLE
Restructure README with improved examples and streamlined API documentation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -6,39 +6,41 @@
 
 **Industrial-grade TMX 1.4b parsing and serialization for Python.**
 
-Hypomnema is a strictly typed infrastructure library for working with [TMX 1.4b](https://resources.gala-global.org/tbx14b) (Translation Memory eXchange) files. It is designed as a foundation for building localization tools, CAT software, and NLP pipelines.
+Hypomnema is a strictly typed infrastructure library for working with [TMX 1.4b](https://resources.gala-global.org/tbx14b) (Translation Memory eXchange) files. It is designed as a foundation for building localization tools, CAT software, and NLP pipelines, focusing on correctness, type safety, and memory efficiency when handling large datasets.
 
-> **Warning:** Hypomnema is pre-1.0 software. Expect breaking changes without notice until version 1.0.0.
+> **Warning**  
+> This project is currently in **Alpha**. It is a work in progress and should not be used for full production workflows until the 1.0 version is released. API changes may occur.
 
 ## Why Hypomnema?
 
-Most TMX parsers are simple XML wrappers. Hypomnema offers:
+While other TMX libraries exist, Hypomnema is built with modern Python engineering standards to address common pain points:
 
-- **Full TMX 1.4b Level 2 Compliance**: Arbitrary inline element nesting depth, complete attribute modeling
-- **Policy-Driven Error Handling**: Configure exactly how to handle malformed data
-- **Backend Agnostic**: Use `lxml` for speed or standard library `xml.etree` for zero-dependency deployments
-- **Full Type Safety**: Modern Python 3.13+ type annotations with structured dataclasses
-- **Roundtrip Integrity**: Deserialize to objects, manipulate, serialize back
-- **Streaming API**: Process large TMX files element-by-element without loading everything into memory
-
-## What is TMX?
-
-TMX (Translation Memory eXchange) is an open XML standard for exchanging translation memory data between tools and providers. A TMX file contains translation units (TU) with source and target language variants (TUV), each containing segmented text. TMX files often include inline markup for formatting, placeholders, and tags that must be preserved during processing.
+- **Strict Type Safety**: Every TMX element is modeled as a typed Python dataclass. This ensures your code is robust, autocompletion works perfectly, and you catch errors at static analysis time rather than runtime.
+- **Policy-Driven Error Handling**: Real-world TMX files are often messy. Instead of crashing on a single malformed date or missing attribute, Hypomnema uses a granular **Policy System**. You define exactly how to handle specific errors (raise, ignore, use default, or keep raw value) without compromising the integrity of the rest of the file.
+- **Full TMX 1.4b Level 2 Compliance**: Supports arbitrary inline element nesting depth and complete attribute modeling.
+- **Memory Efficient**: Supports streaming processing for large TMX files.
+- **Backend Agnostic**: Works with standard `xml` or `lxml` (for performance).
 
 ## Installation
 
+Install using `uv` (recommended):
+
 ```bash
-pip install hypomnema
-# or
 uv add hypomnema
 ```
 
-For maximum performance with large files:
+Or using `pip`:
 
 ```bash
-pip install "hypomnema[lxml]"
+pip install hypomnema
+```
+
+For maximum performance with large files (enables `lxml` backend):
+
+```bash
+uv add "hypomnema[lxml]"
 # or
-uv add hypomnema[lxml]
+pip install "hypomnema[lxml]"
 ```
 
 ## Quick Start
@@ -57,119 +59,76 @@ print(f"Translation units: {len(tmx.body)}")
 for tu in tmx.body:
     for tuv in tu.variants:
         if tuv.lang == "fr":
-            print(f"French: {tuv.text}")
+            print(f"French: {tuv.content}")
 
 # Save changes
 hm.dump(tmx, "output.tmx")
 ```
 
-## High-Level API
+## Advanced Usage
 
-### Loading Files
+### Streaming Large Files
+
+For large translation memories, use the streaming API to process units one by one without loading the whole file into RAM:
 
 ```python
 import hypomnema as hm
 
-# Load entire file
-tmx = hm.load("input.tmx")
-
-# Streaming: yield translation units one at a time (memory efficient)
-for tu in hm.load("large.tmx", filter="tu"):
-    print(tu.tuid)
-
-# Filter multiple element types
-for element in hm.load("file.tmx", filter=["tu", "prop"]):
-    if isinstance(element, hm.Tu):
-        print(element.creationtool)
-    else:
-        print(element.type)
-
-# Specify encoding
-tmx = hm.load("file.tmx", encoding="utf-16")
+# Stream translation units ('tu') only
+for tu in hm.load("massive_memory.tmx", filter="tu"):
+    print(f"Processing TU: {tu.tuid}")
+    # Process units here...
 ```
 
-### Saving Files
+### Creating and Saving TMX Files
+
+You can programmatically create TMX files using the helper factory functions:
 
 ```python
 import hypomnema as hm
+from hypomnema import helpers
 
+# 1. Create a Header
+header = helpers.create_header(
+    creationtool="hypomnema",
+    segtype="sentence",
+    srclang="en-US",
+    adminlang="en-US"
+)
+
+# 2. Create a Translation Unit (TU) with variants
+# TUVs can contain plain text or mixed content with inline tags
+tuv_en = helpers.create_tuv("en-US", content="Hello world")
+tuv_fr = helpers.create_tuv("fr-FR", content=["Bonjour ", helpers.create_ph(x=1, type="lb"), "le monde"])
+
+tu = helpers.create_tu(
+    tuid="1",
+    srclang="en-US",
+    variants=[tuv_en, tuv_fr]
+)
+
+# 3. Create the TMX object
+tmx = helpers.create_tmx(header=header, body=[tu])
+
+# 4. Save to disk
 hm.dump(tmx, "output.tmx")
-hm.dump(tmx, "output.tmx", encoding="utf-16")
 ```
 
-## Element Creation
-
-Convenience functions for creating TMX elements:
-
-```python
-import hypomnema as hm
-
-# Structural elements
-header = hm.create_header(srclang="en", creationtool="my-tool")
-tuv = hm.create_tuv("en", content=["Hello"])
-tu = hm.create_tu(tuid="001", variants=[tuv])
-tmx = hm.create_tmx(header=header, body=[tu])
-
-# Inline elements
-bpt = hm.create_bpt(i=1, type="bold", content=["text"])
-ept = hm.create_ept(i=1)
-it = hm.create_it(pos=hm.Pos.BEGIN, type="italic")
-ph = hm.create_ph(type="variable", x=100)
-hi = hm.create_hi(content=["highlighted"])
-sub = hm.create_sub(content=["sub-flow"], datatype="text")
-
-# Auxiliary elements
-prop = hm.create_prop("customer", "acme-corp")
-note = hm.create_note("Translation note")
-```
-
-## Text Extraction
-
-Extract plain text content from elements, skipping inline markup:
-
-```python
-import hypomnema as hm
-
-tuv = hm.create_tuv(
-    "en",
-    content=[
-        "Hello ",
-        hm.create_bpt(i=1, content="Bpt text"),
-        "World",
-        hm.create_ept(i=1, content="Ept text")
-        ],
-    )
-
-# Quick access via .text property
-print(tuv.text)  # "Hello World"
-
-# Iterate over text segments
-for text in hm.iter_text(tuv):
-    print(text)  # "Hello " then "Bpt text" then "World" then "Ept text"
-
-# Ignore specific element types
-for text in hm.iter_text(tuv, Ignore=[hm.Bpt]):
-    print(text)  # "Hello " then "World" then "Ept text"
-```
-
-## Policy Configuration
+### Policy Configuration
 
 Real-world TMX files are often imperfect. Policies let you configure how Hypomnema handles validation errors:
 
 ```python
 import logging
 import hypomnema as hm
-from hypomnema.xml.policy import PolicyValue
+from hypomnema.xml.policy import Behavior, XmlDeserializationPolicy
 
-policy = hm.XmlPolicy(
-    missing_seg=PolicyValue("ignore", logging.WARNING),
-    extra_text=PolicyValue("ignore", logging.INFO),
-    invalid_attribute_value=PolicyValue("ignore", logging.DEBUG),
-    required_attribute_missing=PolicyValue("ignore", logging.ERROR),
+policy = XmlDeserializationPolicy(
+    missing_seg=Behavior("ignore", logging.WARNING),
+    extra_text=Behavior("ignore", logging.INFO),
 )
 
-tmx = hm.load("messy.tmx", policy=policy)
-hm.dump(tmx, "clean.tmx", policy=policy)
+tmx = hm.load("messy.tmx", deserializer_policy=policy)
 ```
 
 <details>
@@ -177,127 +136,65 @@ hm.dump(tmx, "clean.tmx", policy=policy)
 
 **Deserialization:**
 
-- `missing_handler` — No handler for element type
-- `invalid_tag` — Unexpected XML tag encountered
-- `required_attribute_missing` — Mandatory TMX attribute absent
-- `invalid_attribute_value` — Attribute violates TMX spec
-- `extra_text` — Unexpected text within elements
-- `missing_seg` — TUV missing required segment
-- `multiple_seg` — TUV has multiple segments
-- `empty_content` — Element has no text content
+- `invalid_child_tag`: Action for unexpected child elements.
+- `missing_text_content`: Action for elements missing required text.
+- `invalid_tag`: Action for unexpected element tags.
+- `extra_text`: Action for unexpected text content.
+- `required_attribute_missing`: Action for missing required attributes.
+- `multiple_seg`: Action for multiple <seg> elements in <tuv>.
+- `multiple_headers`: Action for multiple <header> elements.
+- `invalid_datetime_value`: Action for unparsable datetime values.
+- `invalid_enum_value`: Action for invalid enum values.
+- `invalid_int_value`: Action for unparsable integer values.
+- `missing_deserialization_handler`: Action for missing element handlers.
+- `missing_seg`: Action for <tuv> elements without <seg>.
+- `multiple_body`: Action for multiple <body> elements.
+- `missing_header`: Action for <tmx> elements without <header>.
+- `missing_body`: Action for <tmx> elements without <body>.
 
 **Serialization:**
 
-- `required_attribute_missing` — Mandatory dataclass field is None
-- `invalid_attribute_type` — Field type incompatible with XML
-- `invalid_content_type` — Content is not a string
-- `missing_handler` — No handler for dataclass type
-- `invalid_object_type` — Handler received unexpected type
-- `invalid_child_element` — Child not permitted by TMX structure
-- `multiple_headers` — Multiple header elements
-- `missing_header` — Mandatory header missing
+- `invalid_element_type`: Action for unexpected object types.
+- `missing_text_content`: Action for objects missing required text.
+- `required_attribute_missing`: Action for missing required attributes.
+- `invalid_child_element`: Action for invalid child element types.
+- `invalid_attribute_type`: Action for attributes with wrong types.
+- `missing_serialization_handler`: Action for missing element handlers.
 
 **Namespace:**
 
-- `invalid_namespace` — Invalid namespace prefix or URI
-- `existing_namespace` — Namespace already registered
-- `missing_namespace` — Namespace not registered
+- `existing_namespace`: Action when registering an already-existing prefix.
+- `inexistent_namespace`: Action when resolving an unregistered prefix.
 
 </details>
 
-## Low-Level API
+### Text Extraction
 
-For finer control over parsing and serialization:
-
-```python
-import hypomnema as hm
-
-# Choose backend
-backend = hm.LxmlBackend()      # Fast, feature-rich
-# or
-backend = hm.StandardBackend()  # Portable, stdlib only
-
-# Deserialize
-deserializer = hm.Deserializer(backend=backend)
-root = backend.parse("file.tmx")
-tmx = deserializer.deserialize(root)
-
-# Manipulate
-new_tuv = hm.create_tuv("de", content=["Guten Tag"])
-new_tu = hm.create_tu(variants=[new_tuv])
-tmx.body.append(new_tu)
-
-# Serialize
-serializer = hm.Serializer(backend=backend)
-xml_element = serializer.serialize(tmx)
-backend.write(xml_element, "output.tmx")
-```
-
-## QName Support
-
-Work with XML qualified names:
+Extract plain text content from elements, skipping inline markup:
 
 ```python
-from hypomnema.xml.qname import QName
+from hypomnema import helpers, Bpt
 
-# Simple name
-qname = QName("tag")
-
-# Clark notation
-# namespace map required when using prefixed/Clark notation
-qname = QName("{http://www.example.com}tag", nsmap={"ns": "http://www.example.com"})
-print(qname.uri)             # "http://www.example.com"
-print(qname.local_name)      # "tag"
-print(qname.prefix)          # "ns"
-print(qname.qualified_name)  # "{http://www.example.com}tag"
-
-# Use with tag filtering
-for tu in hm.load("file.tmx", filter=qname):
-    print(tu.tuid)
-```
-
-## Creating TMX from Scratch
-
-```python
-import hypomnema as hm
-
-header = hm.create_header(
-    srclang="en",
-    creationtool="my-tool",
-    segtype=hm.Segtype.SENTENCE,
-)
-
-source = hm.create_tuv(
+tuv = helpers.create_tuv(
     "en",
     content=[
-        "Click ",
-        hm.create_bpt(i=1, type="link"),
-        "here",
-        hm.create_ept(i=1),
-        " to continue.",
-    ],
-)
+        "Hello ",
+        helpers.create_bpt(i=1, content="Bpt text"),
+        "World",
+        helpers.create_ept(i=1, content="Ept text")
+        ],
+    )
 
-target = hm.create_tuv(
-    "fr",
-    content=[
-        "Cliquez ",
-        hm.create_bpt(i=1, type="link"),
-        "ici",
-        hm.create_ept(i=1),
-        " pour continuer.",
-    ],
-)
+# Quick access via text helper
+print(helpers.text(tuv))  # "Hello World"
 
-tu = hm.create_tu(
-    tuid="001",
-    variants=[source, target],
-    props=[hm.create_prop("domain", "ui")],
-    notes=[hm.create_note("Button label")],
-)
+# Iterate over text segments
+for text in helpers.iter_text(tuv):
+    print(text)  # "Hello " then "Bpt text" then "World" then "Ept text"
 
-tmx = hm.create_tmx(header=header, body=[tu])
-hm.dump(tmx, "output.tmx")
+# Ignore specific element types
+for text in helpers.iter_text(tuv, ignore=Bpt):
+    print(text)  # "Hello " then "World" then "Ept text"
 ```
 
 ## TMX 1.4b Level 2 Compliance
@@ -309,38 +206,19 @@ Hypomnema is the **only Python library** that fully implements the TMX 1.4b Leve
 - **Full Attribute Modeling**: Every TMX attribute is typed, including enumerations for `segtype`, `pos`, and `assoc`.
 - **Metadata Preservation**: Properties and notes supported at all valid nesting levels.
 
-### Intentionally Omitted Elements
+## Development
 
-- `<ude>` — User Defined Encoding
-- `<map>` — Character mapping
+To contribute or run tests locally:
 
-These elements relate to custom encodings and are rarely encountered. If needed, subclass the handler classes in `xml/deserialization/_handlers.py` and `xml/serialization/_handlers.py`.
-
-## Architecture
-
-Hypomnema is built on three decoupled layers:
-
-1. **Backend Layer** (`hypomnema.xml.backends`) — Abstracts XML parser implementation
-2. **Orchestration Layer** (`hypomnema.xml`) — Manages serialization/deserialization dispatch
-3. **Handler Layer** — Specialized classes for each TMX element type
-
-## Supported Elements
-
-**Structural:** `Tmx`, `Header`, `Tu`, `Tuv`
-
-**Inline:** `Bpt`, `Ept`, `It`, `Ph`, `Hi`, `Sub`
-
-**Auxiliary:** `Prop`, `Note`
-
-**Enumerations:** `Segtype`, `Pos`, `Assoc`
-
-## Terminology Reference
-
-See [TERMINOLOGY.md](./TERMINOLOGY.md) for TMX 1.4b terminology.
-
-## Contributing
-
-Contributions are welcome! Please open an issue before submitting a pull request.
+1. Clone the repository.
+2. Install dependencies using `uv`:
+   ```bash
+   uv sync
+   ```
+3. Run the test suite:
+   ```bash
+   uv run pytest
+   ```
 
 ## License
 


### PR DESCRIPTION
This pull request significantly overhauls the README documentation to improve clarity and user experience. The changes include:

**Enhanced project description and positioning:**
- Expanded the library description to emphasize correctness, type safety, and memory efficiency
- Rewrote the "Why Hypomnema?" section to better articulate the library's unique value propositions
- Updated the warning section to clarify the project's Alpha status

**Improved installation and quick start guidance:**
- Reorganized installation instructions with `uv` as the recommended method
- Updated the quick start example to use the current API (`tuv.content` instead of `tuv.text`)

**Restructured documentation sections:**
- Consolidated the high-level API examples into more focused "Advanced Usage" sections
- Streamlined the element creation examples to use the `helpers` module
- Updated policy configuration examples to use the current `XmlDeserializationPolicy` API
- Replaced the text extraction example to use helper functions (`helpers.text()` and `helpers.iter_text()`)

**Removed outdated content:**
- Eliminated the low-level API section, QName support examples, and detailed architecture descriptions
- Removed the comprehensive supported elements list and terminology reference
- Simplified the contributing section

**Added development section:**
- Included instructions for local development setup and testing

The documentation now provides a more streamlined path for users to understand and adopt the library while focusing on the most common use cases and modern Python development practices.