### PR TITLE
Fix timezone-aware datetime handling for TMX datetime fields

### DIFF
--- a/src/hypomnema/domain/nodes.py
+++ b/src/hypomnema/domain/nodes.py
@@ -13,7 +13,7 @@ can round-trip unsupported content.
 from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Literal
 
 
@@ -167,13 +167,18 @@ class TranslationMemoryHeader:
   ) -> TranslationMemoryHeader:
     """Build a header node from user-facing values.
 
-    Datetime strings are parsed with `datetime.fromisoformat()`. Enum-like
+    Datetime strings are parsed with `datetime.fromisoformat()`. Naive
+    datetimes (without timezone info) are assumed to be UTC. Enum-like
     values are coerced to their TMX enum classes.
     """
     if isinstance(created_at, str):
       created_at = datetime.fromisoformat(created_at)
+      if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=UTC)
     if isinstance(last_modified_at, str):
       last_modified_at = datetime.fromisoformat(last_modified_at)
+      if last_modified_at.tzinfo is None:
+        last_modified_at = last_modified_at.replace(tzinfo=UTC)
     segmentation_type = Segtype(segmentation_type)
     if original_encoding is not None:
       original_encoding = _verify_encoding(original_encoding)
@@ -414,7 +419,8 @@ class TranslationVariant:
   ) -> TranslationVariant:
     """Build a translation variant from user-facing values.
 
-    Datetime strings are parsed with `datetime.fromisoformat()`. Integer-like
+    Datetime strings are parsed with `datetime.fromisoformat()`. Naive
+    datetimes (without timezone info) are assumed to be UTC. Integer-like
     counters are coerced with `int()`. Language strings pass through the
     current language-code verifier before being stored in the internal
     spec-defined attribute dataclass.
@@ -426,10 +432,16 @@ class TranslationVariant:
       usage_count = int(usage_count)
     if isinstance(last_used_at, str):
       last_used_at = datetime.fromisoformat(last_used_at)
+      if last_used_at.tzinfo is None:
+        last_used_at = last_used_at.replace(tzinfo=UTC)
     if isinstance(created_at, str):
       created_at = datetime.fromisoformat(created_at)
+      if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=UTC)
     if isinstance(last_modified_at, str):
       last_modified_at = datetime.fromisoformat(last_modified_at)
+      if last_modified_at.tzinfo is None:
+        last_modified_at = last_modified_at.replace(tzinfo=UTC)
 
     return TranslationVariant(
       spec_attributes=TranslationVariantSpecDefinedAttributes(
@@ -490,7 +502,8 @@ class TranslationUnit:
   ) -> TranslationUnit:
     """Build a translation unit from user-facing values.
 
-    Datetime strings are parsed with `datetime.fromisoformat()`. Enum-like and
+    Datetime strings are parsed with `datetime.fromisoformat()`. Naive
+    datetimes (without timezone info) are assumed to be UTC. Enum-like and
     integer-like metadata is coerced before the node is created.
     """
     if original_encoding is not None:
@@ -499,10 +512,16 @@ class TranslationUnit:
       usage_count = int(usage_count)
     if isinstance(last_used_at, str):
       last_used_at = datetime.fromisoformat(last_used_at)
+      if last_used_at.tzinfo is None:
+        last_used_at = last_used_at.replace(tzinfo=UTC)
     if isinstance(created_at, str):
       created_at = datetime.fromisoformat(created_at)
+      if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=UTC)
     if isinstance(last_modified_at, str):
       last_modified_at = datetime.fromisoformat(last_modified_at)
+      if last_modified_at.tzinfo is None:
+        last_modified_at = last_modified_at.replace(tzinfo=UTC)
     if segmentation_type is not None:
       segmentation_type = Segtype(segmentation_type)
     if source_language is not None:

--- a/src/hypomnema/dumpers/xml.py
+++ b/src/hypomnema/dumpers/xml.py
@@ -369,13 +369,13 @@ class TranslationMemoryHeaderDumper[BackendType](XmlDumper[BackendType, Translat
       self.backend.set_attribute(header_elem, "o-encoding", node.spec_attributes.original_encoding)
     if node.spec_attributes.created_at is not None:
       self.backend.set_attribute(
-        header_elem, "creationdate", node.spec_attributes.created_at.strftime("%Y%m%dT%H%M%S%Z")
+        header_elem, "creationdate", node.spec_attributes.created_at.strftime("%Y%m%dT%H%M%SZ")
       )
     if node.spec_attributes.created_by is not None:
       self.backend.set_attribute(header_elem, "creationid", node.spec_attributes.created_by)
     if node.spec_attributes.last_modified_at is not None:
       self.backend.set_attribute(
-        header_elem, "changedate", node.spec_attributes.last_modified_at.strftime("%Y%m%dT%H%M%S%Z")
+        header_elem, "changedate", node.spec_attributes.last_modified_at.strftime("%Y%m%dT%H%M%SZ")
       )
     if node.spec_attributes.last_modified_by is not None:
       self.backend.set_attribute(header_elem, "changeid", node.spec_attributes.last_modified_by)
@@ -500,7 +500,7 @@ class TranslationVariantDumper[BackendType](XmlDumper[BackendType, TranslationVa
       self.backend.set_attribute(variant_elem, "usagecount", str(node.spec_attributes.usage_count))
     if node.spec_attributes.last_used_at is not None:
       self.backend.set_attribute(
-        variant_elem, "lastusagedate", node.spec_attributes.last_used_at.strftime("%Y%m%dT%H%M%S%Z")
+        variant_elem, "lastusagedate", node.spec_attributes.last_used_at.strftime("%Y%m%dT%H%M%SZ")
       )
     if node.spec_attributes.creation_tool is not None:
       self.backend.set_attribute(variant_elem, "creationtool", node.spec_attributes.creation_tool)
@@ -510,15 +510,13 @@ class TranslationVariantDumper[BackendType](XmlDumper[BackendType, TranslationVa
       )
     if node.spec_attributes.created_at is not None:
       self.backend.set_attribute(
-        variant_elem, "creationdate", node.spec_attributes.created_at.strftime("%Y%m%dT%H%M%S%Z")
+        variant_elem, "creationdate", node.spec_attributes.created_at.strftime("%Y%m%dT%H%M%SZ")
       )
     if node.spec_attributes.created_by is not None:
       self.backend.set_attribute(variant_elem, "creationid", node.spec_attributes.created_by)
     if node.spec_attributes.last_modified_at is not None:
       self.backend.set_attribute(
-        variant_elem,
-        "changedate",
-        node.spec_attributes.last_modified_at.strftime("%Y%m%dT%H%M%S%Z"),
+        variant_elem, "changedate", node.spec_attributes.last_modified_at.strftime("%Y%m%dT%H%M%SZ")
       )
     if node.spec_attributes.last_modified_by is not None:
       self.backend.set_attribute(variant_elem, "changeid", node.spec_attributes.last_modified_by)
@@ -551,7 +549,7 @@ class TranslationUnitDumper[BackendType](XmlDumper[BackendType, TranslationUnit]
       self.backend.set_attribute(tu_elem, "usagecount", str(node.spec_attributes.usage_count))
     if node.spec_attributes.last_used_at is not None:
       self.backend.set_attribute(
-        tu_elem, "lastusagedate", node.spec_attributes.last_used_at.strftime("%Y%m%dT%H%M%S%Z")
+        tu_elem, "lastusagedate", node.spec_attributes.last_used_at.strftime("%Y%m%dT%H%M%SZ")
       )
     if node.spec_attributes.creation_tool is not None:
       self.backend.set_attribute(tu_elem, "creationtool", node.spec_attributes.creation_tool)
@@ -561,13 +559,13 @@ class TranslationUnitDumper[BackendType](XmlDumper[BackendType, TranslationUnit]
       )
     if node.spec_attributes.created_at is not None:
       self.backend.set_attribute(
-        tu_elem, "creationdate", node.spec_attributes.created_at.strftime("%Y%m%dT%H%M%S%Z")
+        tu_elem, "creationdate", node.spec_attributes.created_at.strftime("%Y%m%dT%H%M%SZ")
       )
     if node.spec_attributes.created_by is not None:
       self.backend.set_attribute(tu_elem, "creationid", node.spec_attributes.created_by)
     if node.spec_attributes.last_modified_at is not None:
       self.backend.set_attribute(
-        tu_elem, "changedate", node.spec_attributes.last_modified_at.strftime("%Y%m%dT%H%M%S%Z")
+        tu_elem, "changedate", node.spec_attributes.last_modified_at.strftime("%Y%m%dT%H%M%SZ")
       )
     if node.spec_attributes.segmentation_type is not None:
       self.backend.set_attribute(tu_elem, "segtype", node.spec_attributes.segmentation_type.value)

--- a/tests/domain/test_nodes_create_structural.py
+++ b/tests/domain/test_nodes_create_structural.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 
@@ -91,11 +91,13 @@ def test_translation_memory_header_create_sets_original_encoding() -> None:
 
 
 def test_translation_memory_header_create_parses_created_at() -> None:
-  assert _make_header().spec_attributes.created_at == datetime(2024, 1, 2, 3, 4, 5)
+  assert _make_header().spec_attributes.created_at == datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC)
 
 
 def test_translation_memory_header_create_parses_last_modified_at() -> None:
-  assert _make_header().spec_attributes.last_modified_at == datetime(2024, 2, 3, 4, 5, 6)
+  assert _make_header().spec_attributes.last_modified_at == datetime(
+    2024, 2, 3, 4, 5, 6, tzinfo=UTC
+  )
 
 
 def test_translation_memory_header_create_copies_notes() -> None:
@@ -201,15 +203,17 @@ def test_translation_variant_create_coerces_usage_count() -> None:
 
 
 def test_translation_variant_create_parses_last_used_at() -> None:
-  assert _make_variant().spec_attributes.last_used_at == datetime(2024, 3, 4, 5, 6, 7)
+  assert _make_variant().spec_attributes.last_used_at == datetime(2024, 3, 4, 5, 6, 7, tzinfo=UTC)
 
 
 def test_translation_variant_create_parses_created_at() -> None:
-  assert _make_variant().spec_attributes.created_at == datetime(2024, 3, 1, 1, 2, 3)
+  assert _make_variant().spec_attributes.created_at == datetime(2024, 3, 1, 1, 2, 3, tzinfo=UTC)
 
 
 def test_translation_variant_create_parses_last_modified_at() -> None:
-  assert _make_variant().spec_attributes.last_modified_at == datetime(2024, 3, 5, 6, 7, 8)
+  assert _make_variant().spec_attributes.last_modified_at == datetime(
+    2024, 3, 5, 6, 7, 8, tzinfo=UTC
+  )
 
 
 def test_translation_variant_create_copies_notes() -> None:
@@ -270,15 +274,15 @@ def test_translation_unit_create_coerces_usage_count() -> None:
 
 
 def test_translation_unit_create_parses_last_used_at() -> None:
-  assert _make_unit().spec_attributes.last_used_at == datetime(2024, 4, 5, 6, 7, 8)
+  assert _make_unit().spec_attributes.last_used_at == datetime(2024, 4, 5, 6, 7, 8, tzinfo=UTC)
 
 
 def test_translation_unit_create_parses_created_at() -> None:
-  assert _make_unit().spec_attributes.created_at == datetime(2024, 4, 1, 1, 2, 3)
+  assert _make_unit().spec_attributes.created_at == datetime(2024, 4, 1, 1, 2, 3, tzinfo=UTC)
 
 
 def test_translation_unit_create_parses_last_modified_at() -> None:
-  assert _make_unit().spec_attributes.last_modified_at == datetime(2024, 4, 6, 7, 8, 9)
+  assert _make_unit().spec_attributes.last_modified_at == datetime(2024, 4, 6, 7, 8, 9, tzinfo=UTC)
 
 
 def test_translation_unit_create_sets_segmentation_type() -> None:

--- a/tests/roundtrip/test_roundtrip_inline.py
+++ b/tests/roundtrip/test_roundtrip_inline.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from hypomnema.backends.xml.base import XmlBackend
@@ -50,12 +50,12 @@ def test_variant_node_roundtrip_preserves_known_inline_semantics(
     original_encoding="utf-8",
     original_data_type="html",
     usage_count=3,
-    last_used_at=datetime(2024, 3, 4, 5, 6, 7),
+    last_used_at=datetime(2024, 3, 4, 5, 6, 7, tzinfo=UTC),
     creation_tool="tool",
     creation_tool_version="1.0",
-    created_at=datetime(2024, 3, 1, 1, 2, 3),
+    created_at=datetime(2024, 3, 1, 1, 2, 3, tzinfo=UTC),
     created_by="creator",
-    last_modified_at=datetime(2024, 3, 5, 6, 7, 8),
+    last_modified_at=datetime(2024, 3, 5, 6, 7, 8, tzinfo=UTC),
     last_modified_by="modifier",
     original_tm_format="legacy",
     segment=[
@@ -84,8 +84,8 @@ def test_variant_xml_roundtrip_preserves_known_inline_structure(
     "variant-structure.xml",
     (
       '<tuv xml:lang="en" o-encoding="utf-8" datatype="html" usagecount="3" '
-      'lastusagedate="20240304T050607" creationtool="tool" creationtoolversion="1.0" '
-      'creationdate="20240301T010203" creationid="creator" changedate="20240305T060708" '
+      'lastusagedate="20240304T050607Z" creationtool="tool" creationtoolversion="1.0" '
+      'creationdate="20240301T010203Z" creationid="creator" changedate="20240305T060708Z" '
       'changeid="modifier" o-tmf="legacy">'
       '<seg>lead<ph assoc="b" x="2" type="fmt">inner<sub datatype="xml">sub</sub>tail</ph>'
       'after<hi x="7" type="style">deep</hi>end</seg>'

--- a/tests/roundtrip/test_roundtrip_structural.py
+++ b/tests/roundtrip/test_roundtrip_structural.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from hypomnema.backends.xml.base import XmlBackend
@@ -68,9 +68,9 @@ def test_translation_unit_node_roundtrip_preserves_semantics(
     original_encoding="utf-8",
     original_data_type="xml",
     usage_count=4,
-    last_used_at=datetime(2024, 4, 5, 6, 7, 8),
-    created_at=datetime(2024, 4, 1, 1, 2, 3),
-    last_modified_at=datetime(2024, 4, 6, 7, 8, 9),
+    last_used_at=datetime(2024, 4, 5, 6, 7, 8, tzinfo=UTC),
+    created_at=datetime(2024, 4, 1, 1, 2, 3, tzinfo=UTC),
+    last_modified_at=datetime(2024, 4, 6, 7, 8, 9, tzinfo=UTC),
     segmentation_type="sentence",
     source_language="fr",
     notes=[Note.create(text="unit note")],
@@ -97,9 +97,9 @@ def test_translation_memory_node_roundtrip_preserves_semantics(
       source_language="fr",
       original_data_type="plaintext",
       original_encoding="utf-8",
-      created_at=datetime(2024, 1, 2, 3, 4, 5),
+      created_at=datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC),
       created_by="creator",
-      last_modified_at=datetime(2024, 2, 3, 4, 5, 6),
+      last_modified_at=datetime(2024, 2, 3, 4, 5, 6, tzinfo=UTC),
       last_modified_by="modifier",
       notes=[Note.create(text="header note")],
       props=[Prop.create(text="header prop", kind="domain")],
@@ -127,7 +127,7 @@ def test_translation_memory_xml_roundtrip_preserves_structure(
       '<tmx version="1.5">'
       '<header creationtool="hypomnema" creationtoolversion="1.0" segtype="sentence" '
       'o-tmf="tmx" adminlang="en" srclang="fr" datatype="plaintext" o-encoding="utf-8" '
-      'creationdate="20240102T030405" creationid="creator" changedate="20240203T040506" '
+      'creationdate="20240102T030405Z" creationid="creator" changedate="20240203T040506Z" '
       'changeid="modifier"><note>header note</note><prop type="domain">header prop</prop></header>'
       '<body><tu tuid="tu-1"><tuv xml:lang="en"><seg>Hello</seg></tuv></tu></body>'
       "</tmx>"


### PR DESCRIPTION
- Assume UTC for naive datetime strings: When parsing ISO-format datetime strings via .fromisoformat(), naive datetimes (without timezone info) are now explicitly treated as UTC by attaching tzinfo=UTC. This prevents downstream comparison failures and ensures consistent timezone semantics across TranslationMemoryHeader, TranslationVariant, and TranslationUnit factory methods.
- Fix strftime format from %Z to literal Z: Replaced %Z in strftime format strings with a trailing Z character (%Y%m%dT%H%M%SZ). %Z produces a locale-dependent timezone abbreviation, which is incorrect for the TMX spec's UTC datetime format. The literal Z suffix now correctly signals UTC in serialized XML output.
- Update tests to use aware datetimes: Adjusted all test assertions and roundtrip fixtures to construct datetime objects with tzinfo=UTC, matching the new timezone-aware behavior.

closes #76 
fixes #75  