### PR TITLE
Fix xml:lang loading to use proper Clark notation key

### DIFF
--- a/src/hypomnema/backends/xml/namespace.py
+++ b/src/hypomnema/backends/xml/namespace.py
@@ -37,6 +37,7 @@ from hypomnema.backends.xml.utils import validate_ncname, validate_uri
 
 XML_NS_URI = "http://www.w3.org/XML/1998/namespace"
 XML_NS_PREFIX = "xml"
+XML_LANG_ATTR = f"{{{XML_NS_URI}}}lang"
 
 
 class ResolveResult(NamedTuple):

--- a/src/hypomnema/loaders/xml.py
+++ b/src/hypomnema/loaders/xml.py
@@ -15,6 +15,7 @@ from logging import Logger, getLogger
 from typing import Literal, Protocol, overload
 
 from hypomnema.backends.xml.base import XmlBackend
+from hypomnema.backends.xml.namespace import XML_LANG_ATTR
 from hypomnema.domain.attributes import Assoc, Pos, Segtype
 from hypomnema.domain.nodes import (
   AnyNode,
@@ -197,12 +198,12 @@ class PropLoader[T](XmlLoader[T]):
     text = self.backend.get_text(element)
     if text is None:
       raise ValueError("Missing text content for <prop> element")
-    attrs = self.backend.get_attribute_map(element, notation="local")
+    attrs = self.backend.get_attribute_map(element, notation="qualified")
     try:
       kind = attrs.pop("type")
     except KeyError as e:
       raise ValueError(f"Missing attribute {e.args[0]!r} for <prop> element") from e
-    language = attrs.pop("lang", None)
+    language = attrs.pop(XML_LANG_ATTR, None)
     encoding = attrs.pop("o-encoding", None)
     unknown_loader = self._get_loader("unknown")
     extra_nodes: list[UnknownNode] = [
@@ -230,8 +231,8 @@ class NoteLoader[T](XmlLoader[T]):
     text = self.backend.get_text(element)
     if text is None:
       raise ValueError("Missing text content for <note> element")
-    attrs = self.backend.get_attribute_map(element, notation="local")
-    language = attrs.pop("lang", None)
+    attrs = self.backend.get_attribute_map(element, notation="qualified")
+    language = attrs.pop(XML_LANG_ATTR, None)
     encoding = attrs.pop("o-encoding", None)
     unknown_loader = self._get_loader("unknown")
     extra_nodes = [unknown_loader.load(n) for n in self.backend.iter_children(element)]
@@ -572,11 +573,11 @@ class TranslationVariantLoader[T](XmlLoader[T]):
     if (text := self.backend.get_text(element)) is not None:
       if text.strip():
         raise ValueError(f"Text content for <tuv> element must be empty, got {text!r}")
-    attrs = self.backend.get_attribute_map(element, notation="local")
+    attrs = self.backend.get_attribute_map(element, notation="qualified")
     try:
-      language = attrs.pop("lang")
-    except KeyError as e:
-      raise ValueError(f"Missing attribute {e.args[0]!r} for <tuv> element") from e
+      language = attrs.pop(XML_LANG_ATTR)
+    except KeyError:
+      raise ValueError("Missing attribute 'xml:lang' for <tuv> element") from None
     original_encoding = attrs.pop("o-encoding", None)
     original_data_type = attrs.pop("datatype", None)
     usage_count = attrs.pop("usagecount", None)

--- a/tests/loaders/test_memory_loader.py
+++ b/tests/loaders/test_memory_loader.py
@@ -30,7 +30,7 @@ def load_minimal_memory(backend: XmlBackend[object], tmp_path: Path) -> Translat
       '<tmx version="1.4">'
       '<header creationtool="hypomnema" creationtoolversion="1.0" segtype="sentence" '
       'o-tmf="tmx" adminlang="en" srclang="fr" datatype="plaintext" />'
-      '<body><tu><tuv lang="en"><seg>Hello</seg></tuv></tu></body>'
+      '<body><tu><tuv xml:lang="en"><seg>Hello</seg></tuv></tu></body>'
       "</tmx>"
     ),
   )
@@ -52,7 +52,7 @@ def load_rich_memory(backend: XmlBackend[object], tmp_path: Path) -> Translation
       "<note>header note</note>"
       '<prop type="domain">finance</prop>'
       "</header>"
-      '<body><tu tuid="tu-1"><tuv lang="en"><seg>Hello</seg></tuv></tu></body>'
+      '<body><tu tuid="tu-1"><tuv xml:lang="en"><seg>Hello</seg></tuv></tu></body>'
       "</tmx>"
     ),
   )

--- a/tests/loaders/test_unit_loader.py
+++ b/tests/loaders/test_unit_loader.py
@@ -23,7 +23,7 @@ def parse_payload[T](backend: XmlBackend[T], tmp_path: Path, filename: str, payl
 
 def load_minimal_unit(backend: XmlBackend[object], tmp_path: Path) -> TranslationUnit:
   element = parse_xml(
-    backend, tmp_path, "unit-minimal.xml", '<tu><tuv lang="en"><seg>Hello</seg></tuv></tu>'
+    backend, tmp_path, "unit-minimal.xml", '<tu><tuv xml:lang="en"><seg>Hello</seg></tuv></tu>'
   )
   return TranslationUnitLoader(backend).load(element)
 
@@ -42,8 +42,8 @@ def load_rich_unit(backend: XmlBackend[object], tmp_path: Path) -> TranslationUn
       "<note>unit note</note>"
       '<prop type="domain">finance</prop>'
       '<extra-unit kind="opaque">keep me</extra-unit>'
-      '<tuv lang="en"><seg>Source</seg></tuv>'
-      '<tuv lang="fr"><seg>Cible</seg></tuv>'
+      '<tuv xml:lang="en"><seg>Source</seg></tuv>'
+      '<tuv xml:lang="fr"><seg>Cible</seg></tuv>'
       "</tu>"
     ),
   )
@@ -159,7 +159,7 @@ def test_unit_loader_preserves_unknown_child_payload_tag(
 
 def test_unit_loader_rejects_wrong_tag(backend: XmlBackend[object], tmp_path: Path) -> None:
   element = parse_xml(
-    backend, tmp_path, "unit-wrong-tag.xml", '<tuv lang="en"><seg>Hello</seg></tuv>'
+    backend, tmp_path, "unit-wrong-tag.xml", '<tuv xml:lang="en"><seg>Hello</seg></tuv>'
   )
 
   with pytest.raises(ValueError, match="Expected <tu> element"):

--- a/tests/loaders/test_variant_loader.py
+++ b/tests/loaders/test_variant_loader.py
@@ -23,7 +23,7 @@ def parse_payload[T](backend: XmlBackend[T], tmp_path: Path, filename: str, payl
 
 def load_minimal_variant(backend: XmlBackend[object], tmp_path: Path) -> TranslationVariant:
   element = parse_xml(
-    backend, tmp_path, "variant-minimal.xml", '<tuv lang="en"><seg>Hello world</seg></tuv>'
+    backend, tmp_path, "variant-minimal.xml", '<tuv xml:lang="en"><seg>Hello world</seg></tuv>'
   )
   return TranslationVariantLoader(backend).load(element)
 
@@ -34,12 +34,12 @@ def load_rich_variant(backend: XmlBackend[object], tmp_path: Path) -> Translatio
     tmp_path,
     "variant-rich.xml",
     (
-      '<tuv lang="de" o-encoding="utf-8" datatype="html" usagecount="7" '
+      '<tuv xml:lang="de" o-encoding="utf-8" datatype="html" usagecount="7" '
       'lastusagedate="2024-03-04T05:06:07" creationtool="tool" '
       'creationtoolversion="2.0" creationdate="2024-03-01T01:02:03" '
       'creationid="creator" changedate="2024-03-05T06:07:08" '
       'changeid="modifier" o-tmf="legacy" custom="value">'
-      '<note lang="fr">note</note>'
+      '<note xml:lang="fr">note</note>'
       '<prop type="domain">billing</prop>'
       '<extra-top flag="1">keep me</extra-top>'
       '<seg>lead<ph assoc="b" x="2" type="fmt">inner<sub datatype="xml">sub</sub>tail</ph>'
@@ -240,7 +240,7 @@ def test_variant_loader_allows_whitespace_outside_seg(
   backend: XmlBackend[object], tmp_path: Path
 ) -> None:
   element = parse_xml(
-    backend, tmp_path, "variant-whitespace.xml", '<tuv lang="en">  <seg>Hello</seg></tuv>'
+    backend, tmp_path, "variant-whitespace.xml", '<tuv xml:lang="en">  <seg>Hello</seg></tuv>'
   )
 
   assert TranslationVariantLoader(backend).load(element).segment == ["Hello"]
@@ -250,7 +250,7 @@ def test_variant_loader_rejects_non_whitespace_text_outside_seg(
   backend: XmlBackend[object], tmp_path: Path
 ) -> None:
   element = parse_xml(
-    backend, tmp_path, "variant-text.xml", '<tuv lang="en">unexpected<seg>Hello</seg></tuv>'
+    backend, tmp_path, "variant-text.xml", '<tuv xml:lang="en">unexpected<seg>Hello</seg></tuv>'
   )
 
   with pytest.raises(ValueError, match="Text content for <tuv> element must be empty"):
@@ -260,13 +260,13 @@ def test_variant_loader_rejects_non_whitespace_text_outside_seg(
 def test_variant_loader_requires_lang(backend: XmlBackend[object], tmp_path: Path) -> None:
   element = parse_xml(backend, tmp_path, "variant-missing-lang.xml", "<tuv><seg>Hello</seg></tuv>")
 
-  with pytest.raises(ValueError, match="Missing attribute 'lang'"):
+  with pytest.raises(ValueError, match="Missing attribute 'xml:lang'"):
     TranslationVariantLoader(backend).load(element)
 
 
 def test_variant_loader_requires_seg(backend: XmlBackend[object], tmp_path: Path) -> None:
   element = parse_xml(
-    backend, tmp_path, "variant-missing-seg.xml", '<tuv lang="en"><note>note</note></tuv>'
+    backend, tmp_path, "variant-missing-seg.xml", '<tuv xml:lang="en"><note>note</note></tuv>'
   )
 
   with pytest.raises(ValueError, match="Missing <seg> element"):
@@ -280,7 +280,7 @@ def test_variant_loader_rejects_multiple_seg_elements(
     backend,
     tmp_path,
     "variant-multiple-seg.xml",
-    '<tuv lang="en"><seg>one</seg><seg>two</seg></tuv>',
+    '<tuv xml:lang="en"><seg>one</seg><seg>two</seg></tuv>',
   )
 
   with pytest.raises(ValueError, match="Multiple <seg> elements"):


### PR DESCRIPTION
## Summary

- Loaders for `<tuv>`, `<note>`, and `<prop>` now look up the language attribute using the Clark notation key `{http://www.w3.org/XML/1998/namespace}lang` (exposed as `XML_LANG_ATTR`) instead of relying on `get_attribute_map(notation="local")` which strips the namespace prefix down to just `"lang"`.

## Why

The TMX spec defines the language attribute as `xml:lang` (with the XML namespace prefix). The dumper already writes it correctly via `set_attribute(element, "xml:lang", ...)`, which resolves to the Clark-notation key `{http://www.w3.org/XML/1998/namespace}lang`. However, the loaders were popping `"lang"` from the attribute map returned by `get_attribute_map(notation="local")`, which:

1. Silently accepts a non-namespaced `lang` attribute (invalid but present in some files).
2. Misses the attribute if a different namespace prefix maps to the XML namespace URI.

## Changes

- Added `XML_LANG_ATTR` constant to `namespace.py` for the `{http://www.w3.org/XML/1998/namespace}lang` Clark notation key.
- `PropLoader`, `NoteLoader`, `TranslationVariantLoader` now use `notation="qualified"` and pop `XML_LANG_ATTR` instead of `"lang"`.
- Updated error message in `TranslationVariantLoader` from `Missing attribute 'lang'` to `Missing attribute 'xml:lang'`.
- Updated test XML strings to use spec-compliant `xml:lang="…"` instead of bare `lang="…"`.

Closes #74